### PR TITLE
Validate mic duration

### DIFF
--- a/main/main.py
+++ b/main/main.py
@@ -327,7 +327,14 @@ def webcam():
 def mic():
     if not sd:
         abort(501)
-    dur = float(request.args.get("sec", 5))
+    sec_raw = request.args.get("sec", "5")
+    try:
+        dur = float(sec_raw)
+    except (TypeError, ValueError):
+        abort(400)
+    if dur <= 0:
+        abort(400)
+    dur = min(dur, 10.0)
     fs = 44100
     rec = sd.rec(int(dur*fs), samplerate=fs, channels=1); sd.wait()
     tmp = io.BytesIO(); sf.write(tmp, rec, fs, format="WAV"); tmp.seek(0)


### PR DESCRIPTION
## Summary
- validate `sec` query arg for `/mic` endpoint
- clamp the recording duration to a max of 10 seconds

## Testing
- `python -m py_compile main/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685b4dd007cc8325b88463ac9fafe800